### PR TITLE
CASMCMS-7432: non-root container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,5 +68,7 @@ RUN cd /app/crus && NOX_DOCKER_BUILD=yes nox
 #
 #     /app/entrypoints/controller.sh
 FROM base as app
+RUN groupadd -g 65534 nobody && useradd -u 65534 -g nobody nobody && chown -R nobody:nobody /app
+USER 65534:65534
 COPY config/gunicorn.py /app/
 ENTRYPOINT ["/app/entrypoints/api_server.sh"]


### PR DESCRIPTION
### Summary and Scope

Use the nobody user to run the crus app in the container image.

### Issues and Related PRs

* Resolves CASMCMS-7432

### Testing

Tested on:

* gamora

Were the install/upgrade based validation checks/tests run? N
Was a fresh Install tested? N, no system available
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y

Updated the system with the new chart.

```
ncn-m001:~/rkleinman # loftsman ship --manifest-path ./manifest.yaml
2021-10-01T20:51:49Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2021-10-01T20:51:49Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2021-10-01T20:51:49Z INF Ensuring that the loftsman namespace exists command=ship
2021-10-01T20:51:49Z INF Running a release for the provided manifest at ./manifest.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-crus v0.7432.142-20211001165145+eb89197
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2021-10-01T20:51:50Z INF Running helm install/upgrade with arguments: upgrade --install cray-crus https://artifactory.algol60.net/artifactory/csm-helm-charts/unstable/cray-crus/cray-crus-0.7432.142-20211001165145+eb89197.tgz --namespace services --create-namespace --set global.chart.name=cray-crus --set global.chart.version=0.7432.142-20211001165145+eb89197 chart=cray-crus command=ship namespace=services version=0.7432.142-20211001165145+eb89197
2021-10-01T20:51:51Z INF Release "cray-crus" has been upgraded. Happy Helming!
NAME: cray-crus
LAST DEPLOYED: Fri Oct  1 20:51:50 2021
NAMESPACE: services
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
Installation info for chart cray-crus:
 chart=cray-crus command=ship namespace=services version=0.7432.142-20211001165145+eb89197
2021-10-01T20:51:51Z INF Ship status: success. Recording status, manifest, and log data to configmap loftsman-crus-testing in namespace loftsman command=ship
ncn-m001:~/rkleinman # kubectl get pods -n services | grep crus
cray-crus-55b6765c99-qml6g                                     4/4     Running             0          8d
cray-crus-6d797bc696-4dlj2                                     4/4     Running     0          23s
cray-crus-etcd-77bjf4h9xz                                      1/1     Running             0          8d
cray-crus-etcd-l6xp87ms25                                      1/1     Running             0          9d
cray-crus-etcd-mwtcqfqt4x                                      1/1     Running             0          8d
cray-crus-wait-for-etcd-2-5l5w7                                0/1     Completed           0          23s
ncn-m001:~/rkleinman # kubectl logs -f -n services cray-crus-6d797bc696-4dlj2
error: a container name must be specified for pod cray-crus-6d797bc696-4dlj2, choose one of: [cray-crua cray-crus munge istio-proxy] or one of the init containers: [cray-crus-wait-for-etcd istio-init]
ncn-m001:~/rkleinman # kubectl logs -f -n services cray-crus-6d797bc696-4dlj2 -c cray-crus
[2021-10-01 20:52:14 +0000] [1] [INFO] Starting gunicorn 19.10.0
[2021-10-01 20:52:14 +0000] [1] [INFO] Listening at: http://0.0.0.0:8080 (1)
[2021-10-01 20:52:14 +0000] [1] [INFO] Using worker: sync
[2021-10-01 20:52:14 +0000] [9] [INFO] Booting worker with pid: 9
configuring the application
done configuring
127.0.0.1 - - [01/Oct/2021:20:52:19 +0000] "GET /session HTTP/1.1" 200 3 "-" "kube-probe/1.19"
```

### Risks and Mitigations

None

Requires:

* Fresh install
* Platform upgrade