### PR TITLE
CASMCMS-7655: Get slurm RPM from arti.dev, not car.dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Cray Compute Rolling Upgrade Service Dockerfile
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 # Create 'base' image target
 ARG BASE_IMAGE=arti.dev.cray.com/baseos-docker-master-local/sles15sp2:sles15sp2
 FROM $BASE_IMAGE as base
-ARG SLURM_REPO=http://car.dev.cray.com/artifactory/wlm-slurm/RM/sle15_sp2_cn/x86_64/release/wlm-slurm-1.0/
+ARG SLURM_REPO=https://arti.dev.cray.com/artifactory/wlm-slurm-rpm-stable-local/release/wlm-slurm-1.0/sle15_sp2_cn/
 RUN zypper --non-interactive ar --gpgcheck-allow-unsigned $SLURM_REPO wlm_slurm && \
     zypper --non-interactive refresh && \
     zypper --non-interactive install --recommends bash curl rpm && \


### PR DESCRIPTION
## Summary and Scope

Instead of having the Dockerfile grab the slurm RPM from car.dev, get it from arti.dev. Other than that, this PR contains no changes. There will not be a 1.0 manifest PR for this. This change is just being made so that if we need to make a real CRUS change in 1.0 later, it will still be buildable.

## Issues and Related PRs

None

## Testing

None beyond verifying that it builds.

## Risks and Mitigations

Very low risk. Same RPM is being installed, just from a different location.


## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

