### PR TITLE
CASMCMS-7785/CASMCMS-7655: New munge version; New slurm version; New slurm RPM location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Cray Compute Rolling Upgrade Service Dockerfile
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 # Create 'base' image target
 ARG BASE_IMAGE=arti.dev.cray.com/baseos-docker-master-local/sles15sp3:sles15sp3
 FROM $BASE_IMAGE as base
-ARG SLURM_REPO=http://car.dev.cray.com/artifactory/wlm-slurm/RM/sle15_sp2_cn/x86_64/release/wlm-slurm-1.0/
+ARG SLURM_REPO=http://car.dev.cray.com/artifactory/wlm-slurm/RM/sle15_sp3_cn/x86_64/release/wlm-slurm-1.1/
 RUN zypper --non-interactive ar --gpgcheck-allow-unsigned $SLURM_REPO wlm_slurm && \
     zypper --non-interactive refresh && \
     zypper --non-interactive install --recommends bash curl rpm && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # Create 'base' image target
 ARG BASE_IMAGE=arti.dev.cray.com/baseos-docker-master-local/sles15sp3:sles15sp3
 FROM $BASE_IMAGE as base
-ARG SLURM_REPO=http://car.dev.cray.com/artifactory/wlm-slurm/RM/sle15_sp3_cn/x86_64/release/wlm-slurm-1.1/
+ARG SLURM_REPO=https://arti.dev.cray.com/artifactory/wlm-slurm-rpm-stable-local/release/wlm-slurm-1.1/sle15_sp3_cn/
 RUN zypper --non-interactive ar --gpgcheck-allow-unsigned $SLURM_REPO wlm_slurm && \
     zypper --non-interactive refresh && \
     zypper --non-interactive install --recommends bash curl rpm && \

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -83,4 +83,4 @@ image: munge-munge
     server: arti
     team: wlm-slurm
     major: 1
-    minor: 0
+    minor: 1


### PR DESCRIPTION
## Summary and Scope

This PR contains 3 changes:
* Instead of having the Dockerfile grab the slurm RPM from car.dev, get it from arti.dev. 
* Get the correct slurm version for csm-1.2 (previously we had been using the csm-1.0 version, as the slurm RPM was not available yet)
* Use munge 1.1 to pick up security fixes

Other than that, this PR contains no changes. 

## Issues and Related PRs

[csm-1.0 PR for just CASMCMS-7655](https://github.com/Cray-HPE/cray-crus/pull/11)

## Testing

None beyond verifying that it builds, and that the new docker image gets a clean bill of health from snyk.

## Risks and Mitigations

Hard to say, since we cannot really test CRUS at this point. But we need to pick up the security fixes, we need to get the RPM from the new location, and we need to use the correct slurm version. So whether or not there is risk, this is necessary. And no CRUS logic or functionality is being changed here.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

