### PR TITLE
CASMCMS-7831 - update to use patched version of munge-munge to resolve CVE's

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,13 @@ Currently the openapi.yaml file is kept up to date manually. This is to be
 changed in the future.
 
 ### Dependency: munge-munge
-CRUS uses the munge image provided by the wlm-slurm team. 
-We specify which major and minor version of the image we want with the 
-[update_external_versions.conf](update_external_versions.conf) file.
-At build time the [runBuildPrep.sh](runBuildPrep.sh) script finds the
-latest version with that major and minor number.
+CRUS uses the munge image built by the container-images repo.
+This image is rebuilt periodically to patch security issues, but if
+a new version is required modify the build files in container-images
+and manually update the version used by cray-crus.
 
-When creating a new release branch, be sure to update this file to specify the
-desired major and minor number of the image for the new release.
+This relies on munge secrets put in place by PE so periocially this may need
+to be updated based on system changes.
 
 ## Build Helpers
 This repo uses some build helpers from the 

--- a/kubernetes/cray-crus/values.yaml
+++ b/kubernetes/cray-crus/values.yaml
@@ -105,8 +105,8 @@ cray-service:
     munge:
       name: munge
       image:
-        repository: arti.dev.cray.com/wlm-slurm-docker-master-local/munge-munge
-        tag: 1.1.2-20220210194015_e8cc1ca
+        repository: artifactory.algol60.net/csm-docker/stable/munge-munge
+        tag: 1.1.3
         pullPolicy: IfNotPresent
       resources:
         requests:


### PR DESCRIPTION
## Summary and Scope
The munge-munge image used in cray-crus was provided by PE, however there were CVE vulnerabilities and they were not creating a new stable version until the next complete release of their software.  Since munge is open source, we started with their Dockerfile and used it to build our own version of the image with the security patches supplied.

PR to build munge-munge image:
https://github.com/Cray-HPE/container-images/pull/393

## Issues and Related PRs
* Resolves [CASMCMS-7831](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7831)

## Testing
### Tested on:
  * Local development environment

### Test description:

After all needed images were built, I used snyk to locally verify that all security vulnerabilities are resolved.

Due to the need for a 1.2 system with a complete PE install and available compute nodes to boot, there is no system currently available that can be used to test cray-crus.  No system testing was done.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - no system available.
- Was upgrade tested? If not, why? N - no system available.
- Was downgrade tested? If not, why? N - no system available.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a medium risk change.  The new munge-munge image was built using the existing PE Dockerfile as a base, but needed to be modified to get it to build from the container-images github actions workflows.  To all appearances this should replicate the PE munge-munge image, but without a system to test on we can't 100% insure there isn't some unknown issue.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct

