### PR TITLE
CASMTRIAGE-3526: fix the munge container to run as the munge user.

### DIFF
--- a/kubernetes/cray-crus/values.yaml
+++ b/kubernetes/cray-crus/values.yaml
@@ -134,6 +134,10 @@ cray-service:
             - "mount | grep ' /munge ' && mount | grep '/run/munge '"
         initialDelaySeconds: 5
         periodSeconds: 3
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 481
+        runAsGroup: 481
       volumeMounts:
         - mountPath: /munge
           name: munge-key


### PR DESCRIPTION
## Summary and Scope

The munge container needs to run as the 'munge' user to successfully start the munged process - running as the default 'nobody' user does not work in this context.  This is still a non-root user so the security concerns are met while running as the munge user.

## Issues and Related PRs
* Resolves [CASMTRIAGE-3526](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3526)

## Testing
### Tested on:

  * `Hela`

### Test description:

I updated to the new munge-munge image on hela, then updated the deployment to use that image, and run as the munge:munge user/group.  The service came up and is 'ready' as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low-risk change - just changing the user the munge sidecar is running under and it will not start correctly as-is.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

