### PR TITLE
CASMCMS-8074: Use HSM v2 API instead of v1

### DIFF
--- a/crus/config.py
+++ b/crus/config.py
@@ -73,7 +73,7 @@ class DefaultConfig:
     NODE_GROUP_URI = uri_compose("CRUS_NODE_GROUP_URI",
                                  "CRUS_API_URI",
                                  "https://api-gw-service-nmn.local/apis",
-                                 "smd/hsm/v1/groups")
+                                 "smd/hsm/v2/groups")
     MOCK_BOOT = bool_from_env('CRUS_MOCK_BOOT', default='no')
     UPGRADE_DATA_DIR = os.environ.get('UPGRADE_DATA_DIR', "/upgrade_data")
     BOOT_STATUS_DELAY = float(
@@ -117,7 +117,7 @@ class DevelopmentConfig(DefaultConfig):
     NODE_GROUP_URI = uri_compose("CRUS_NODE_GROUP_URI",
                                  "CRUS_API_URI",
                                  "https://api-gw-service-nmn.local/apis",
-                                 "smd/hsm/v1/groups")
+                                 "smd/hsm/v2/groups")
     MOCK_BOOT = bool_from_env('CRUS_MOCK_BOOT', default='no')
     UPGRADE_DATA_DIR = os.environ.get('UPGRADE_DATA_DIR', "/upgrade_data")
     BOOT_STATUS_DELAY = float(
@@ -160,7 +160,7 @@ class TestingConfig(DefaultConfig):
     NODE_GROUP_URI = uri_compose("CRUS_NODE_GROUP_URI",
                                  "CRUS_API_URI",
                                  "https://api-gw-service-nmn.local/apis",
-                                 "smd/hsm/v1/groups")
+                                 "smd/hsm/v2/groups")
     MOCK_BOOT = bool_from_env('CRUS_MOCK_BOOT', default='yes')
     UPGRADE_DATA_DIR = os.environ.get('UPGRADE_DATA_DIR', "/upgrade_data")
     BOOT_STATUS_DELAY = float(
@@ -182,7 +182,7 @@ class TestingConfig(DefaultConfig):
     NODE_GROUP_URI = uri_compose("CRUS_NODE_GROUP_URI",
                                  "CRUS_API_URI",
                                  "https://api-gw-service-nmn.local/apis",
-                                 "smd/hsm/v1/groups")
+                                 "smd/hsm/v2/groups")
     MOCK_BOOT = bool_from_env('CRUS_MOCK_BOOT', default='yes')
     UPGRADE_DATA_DIR = os.environ.get('UPGRADE_DATA_DIR', "/upgrade_data")
     BOOT_STATUS_DELAY = float(
@@ -225,7 +225,7 @@ class ProductionConfig(DefaultConfig):
     NODE_GROUP_URI = uri_compose("CRUS_NODE_GROUP_URI",
                                  "CRUS_API_URI",
                                  "https://api-gw-service-nmn.local/apis",
-                                 "smd/hsm/v1/groups")
+                                 "smd/hsm/v2/groups")
     MOCK_BOOT = bool_from_env('CRUS_MOCK_BOOT', default='no')
     UPGRADE_DATA_DIR = os.environ.get('UPGRADE_DATA_DIR', "/upgrade_data")
     BOOT_STATUS_DELAY = float(

--- a/kubernetes/cray-crus/values.yaml
+++ b/kubernetes/cray-crus/values.yaml
@@ -85,7 +85,7 @@ cray-service:
         - name: BOOT_SESSION_URI
           value: "http://cray-bos/v1/session"
         - name: CRUS_NODE_GROUP_URI
-          value: "http://cray-smd/hsm/v1/groups"
+          value: "http://cray-smd/hsm/v2/groups"
         - name: CRUS_BSS_HOSTS_URI
           value: "http://cray-bss/boot/v1/hosts"
       resources:


### PR DESCRIPTION
## Summary and Scope

Just what the description says.

Only the groups endpoint is user. I verified that its input and output formats are not altered from v1 to v2.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
